### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/pull-request-commit.yml
+++ b/.github/workflows/pull-request-commit.yml
@@ -41,10 +41,10 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: dist-${{ matrix.os }}-${{ matrix.pyver }}
-      #- run: pip install --pre --find-links=. dgpost[testing]
-      #  shell: bash
-      - run: pip install -e .[testing]
+      - run: pip install --pre --find-links=. dgpost[testing]
         shell: bash
+      #- run: pip install -e .[testing]
+      #  shell: bash
       - uses: ./.github/workflows/test-job
   pages:
     needs: [build]
@@ -64,10 +64,10 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: dist-${{ matrix.os }}-${{ matrix.pyver }}
-      #- run: pip install --pre --find-links=. dgpost[docs]
-      #  shell: bash
-      - run: pip install -e .[docs]
+      - run: pip install --pre --find-links=. dgpost[docs]
         shell: bash
+      #- run: pip install -e .[docs]
+      #  shell: bash
       - uses: ./.github/workflows/docs-job
       - uses: actions/upload-artifact@v2
         with: 

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -32,10 +32,10 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: dist-master
-      #- run: pip install --pre --find-links=. dgpost[testing]
-      #  shell: bash
-      - run: pip install -e .[testing]
+      - run: pip install --pre --find-links=. dgpost[testing]
         shell: bash
+      #- run: pip install -e .[testing]
+      #  shell: bash
       - uses: ./.github/workflows/test-job
   pages:
     needs: [build]
@@ -51,10 +51,10 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: dist-master
-      #- run: pip install --pre --find-links=. dgpost[docs]
-      #  shell: bash
-      - run: pip install -e .[docs]
+      - run: pip install --pre --find-links=. dgpost[docs]
         shell: bash
+      #- run: pip install -e .[docs]
+      #  shell: bash
       - uses: ./.github/workflows/docs-job
       - uses: actions/upload-artifact@v2
         with: 

--- a/.github/workflows/test-job/action.yml
+++ b/.github/workflows/test-job/action.yml
@@ -3,5 +3,7 @@ description: "Test the package with pytest."
 runs:
   using: "composite"
   steps:
+    - run: dgpost --version
+      shell: bash
     - run: pytest
       shell: bash


### PR DESCRIPTION
Reverts CI on GHA back to pulling `dgpost` as built in the `[build]` step, as opposed to installing using `pip install -e .`.