### PR TITLE
Test versions more thoroughly

### DIFF
--- a/.github/workflows/pull-request-commit.yml
+++ b/.github/workflows/pull-request-commit.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     strategy:
       matrix:
-        pyver: ['3.9']
+        pyver: ['3.9', '3.10']
         os: ['ubuntu-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
     steps:
@@ -27,7 +27,7 @@ jobs:
     needs: [build]
     strategy:
       matrix:
-        pyver: ['3.9']
+        pyver: ['3.9', '3.10']
         os: ['ubuntu-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
     steps:

--- a/setup.py
+++ b/setup.py
@@ -24,13 +24,15 @@ setuptools.setup(
         "Documentation": "https://dgbowl.github.io/dgpost/"
     },
     classifiers=[
-        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
         "Operating System :: OS Independent",
     ],
     package_dir={"": packagedir},
     packages=setuptools.find_packages(where=packagedir),
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     install_requires=[
         "numpy",
         "uncertainties",
@@ -38,7 +40,7 @@ setuptools.setup(
         "openpyxl",
         "pint>=0.18",
         "chemicals>=1.0.0",
-        "rdkit-pypi>=2021",
+        "rdkit-pypi>=2022",
         "yadg>=4.1.0rc1",
         "dgbowl-schemas>=102",
         "matplotlib>=3.5.0",


### PR DESCRIPTION
Test supported combinations (`python=[3.9,3.10]` on `windows-latest` and `linux-latest`). Also bump dependencies.