### PR TITLE
Implement `--patch` argument

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -28,6 +28,18 @@ than one command can be specified for each of the keywords (i.e. it's possible t
 syntax of each of the above steps is further described in the documentation of each
 of the keywords within the :mod:`dgpost.utils` module.
 
+dgpost can be used to process multiple datasets, in a batch-like mode, using the 
+``--patch`` argument. For this, the `recipe` has to contain either ``$patch`` or
+``$PATCH`` in the :class:`str` defining the path of the loaded file. Then, dgpost 
+can be executed using
+
+.. code::
+
+    dgpost --patch <patchname> <yamlfile>
+  
+and the paths in the provided ``yamlfile`` containing the `recipe` will be patched
+using ``patchname``.
+
 **dgpost** as a Python library
 ``````````````````````````````
 For advanced users and more complex workflows, dgpost can be also imported as a

--- a/src/dgpost/main.py
+++ b/src/dgpost/main.py
@@ -14,7 +14,7 @@ import copy
 from dgpost.utils import parse, load, extract, transform, save, plot
 
 
-def run(path: str) -> tuple[dict, dict]:
+def run(path: str, patch: str = None) -> tuple[dict, dict]:
     """
     Main API execution function. Loads the `recipe` from the provided ``path``,
     and processes the following entries, in order:
@@ -53,10 +53,14 @@ def run(path: str) -> tuple[dict, dict]:
     tables = {}
     l = spec.pop("load")
     for el in l:
-        if el["type"] == "datagram":
-            datagrams[el["as"]] = load(el["path"], el["check"], el["type"])
+        if patch is None:
+            fp = el["path"]
         else:
-            tables[el["as"]] = load(el["path"], el["check"], el["type"])
+            fp = el["path"].replace("$patch", patch).replace("$PATCH", patch)
+        if el["type"] == "datagram":
+            datagrams[el["as"]] = load(fp, el["check"], el["type"])
+        else:
+            tables[el["as"]] = load(fp, el["check"], el["type"])
 
     e = spec.get("extract", [])
     for el in e:
@@ -137,6 +141,13 @@ def run_with_arguments():
     )
 
     parser.add_argument(
+        "--patch",
+        "-p",
+        help="Patch the YAML infile using the provided file name.",
+        default=None,
+    )
+
+    parser.add_argument(
         "infile",
         help="File containing the YAML to be processed by dgpost.",
         default=None,
@@ -148,4 +159,4 @@ def run_with_arguments():
     logging.basicConfig(level=loglevel)
     logging.debug(f"loglevel set to '{logging._levelToName[loglevel]}'")
 
-    run(args.infile)
+    run(args.infile, patch=args.patch)

--- a/src/dgpost/main.py
+++ b/src/dgpost/main.py
@@ -17,7 +17,8 @@ from dgpost.utils import parse, load, extract, transform, save, plot
 def run(path: str, patch: str = None) -> tuple[dict, dict]:
     """
     Main API execution function. Loads the `recipe` from the provided ``path``,
-    and processes the following entries, in order:
+    patches the file paths specified within the `recipe`, if necessary, and 
+    processes the following entries, in order:
 
     - :mod:`~dgpost.utils.load`,
     - :mod:`~dgpost.utils.extract`,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -134,3 +134,36 @@ def test_run_with_plot(inpath, tname, outpath, outfig, datadir):
     ref = pd.read_pickle(outpath)
     compare_dfs(df, ref)
     compare_images("test.png", outfig)
+
+
+
+
+@pytest.mark.parametrize(
+    "inpath, patch, tname, outpath",
+    [
+        (  # ts0
+            "lee_2a.yaml",
+            None,
+            "df",
+            "lee_2.pkl"
+        ),
+        (  # ts1
+            "lee_2c.yaml",
+            "normalized.dg.json",
+            "df",
+            "lee_2.pkl"
+        ),
+        (  # ts2
+            "lee_2d.yaml",
+            "sparse",
+            "df",
+            "lee_2.pkl"
+        ),
+    ],
+)
+def test_run_with_patch(inpath, patch, tname, outpath, datadir):
+    os.chdir(datadir)
+    dg, tab = dgpost.run(inpath, patch=patch)
+    df = tab[tname]
+    ref = pd.read_pickle(outpath)
+    compare_dfs(df, ref)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -136,29 +136,12 @@ def test_run_with_plot(inpath, tname, outpath, outfig, datadir):
     compare_images("test.png", outfig)
 
 
-
-
 @pytest.mark.parametrize(
     "inpath, patch, tname, outpath",
     [
-        (  # ts0
-            "lee_2a.yaml",
-            None,
-            "df",
-            "lee_2.pkl"
-        ),
-        (  # ts1
-            "lee_2c.yaml",
-            "normalized.dg.json",
-            "df",
-            "lee_2.pkl"
-        ),
-        (  # ts2
-            "lee_2d.yaml",
-            "sparse",
-            "df",
-            "lee_2.pkl"
-        ),
+        ("lee_2a.yaml", None, "df", "lee_2.pkl"),  # ts0
+        ("lee_2c.yaml", "normalized.dg.json", "df", "lee_2.pkl"),  # ts1
+        ("lee_2d.yaml", "sparse", "df", "lee_2.pkl"),  # ts2
     ],
 )
 def test_run_with_patch(inpath, patch, tname, outpath, datadir):

--- a/tests/test_main/lee_2c.yaml
+++ b/tests/test_main/lee_2c.yaml
@@ -1,0 +1,24 @@
+version: v1.0
+load:
+  - as: norm
+    path: $patch
+  - as: sparse
+    path: sparse.dg.json
+extract:
+  - into: df
+    from: norm
+    at:
+      step: "a"
+    columns:
+      - key: raw->T_f
+        as: rawT
+      - key: derived->T
+        as: derT
+  - into: df
+    from: sparse
+    at:
+      steps: ["b1", "b2", "b3"]
+    columns:
+      - key: derived->xout->*
+        as: xout
+  

--- a/tests/test_main/lee_2d.yaml
+++ b/tests/test_main/lee_2d.yaml
@@ -1,0 +1,24 @@
+version: v1.0
+load:
+  - as: norm
+    path: normalized.dg.json
+  - as: sparse
+    path: $PATCH.dg.json
+extract:
+  - into: df
+    from: norm
+    at:
+      step: "a"
+    columns:
+      - key: raw->T_f
+        as: rawT
+      - key: derived->T
+        as: derT
+  - into: df
+    from: sparse
+    at:
+      steps: ["b1", "b2", "b3"]
+    columns:
+      - key: derived->xout->*
+        as: xout
+  


### PR DESCRIPTION
Implements `--patch / -p` as an optional argument, using which the `yamlfile` can be patched to point to load different files using a command line argument. For this, the `yamlfile` has to contain `$patch` or `$PATCH` as part of the `load->path` entry string.

- [x] added tests
- [x] added docs

Closes #30.