### PR TITLE
Fixes to the `conversion` module

### DIFF
--- a/src/dgpost/transform/catalysis.py
+++ b/src/dgpost/transform/catalysis.py
@@ -80,7 +80,7 @@ def conversion(
 
     Which requires the feedstock :math:`f` to be quantified in the outlet composition.
 
-    If the outlet composition of :math:`f` is not defined or not suitable, the user 
+    If the outlet composition of :math:`f` is not defined or not suitable, the user
     should request a "mixed" conversion :math:`X_m`, which is calculated using:
 
     .. math::
@@ -152,8 +152,8 @@ def conversion(
 
     type
         Conversion type. Can be one of ``{"reactant", "product", "mixed"}``, selecting
-        the conversion calculation algorithm. 
-    
+        the conversion calculation algorithm.
+
     product
         **Deprecated.** Switches between reactant and product-based conversion.
 
@@ -355,8 +355,8 @@ def catalytic_yield(
 ) -> None:
     """
     Calculates the catalytic yield :math:`Y_p`, defined as the product of conversion
-    and selectivity. By default, uses product-based conversion of feedstock for an 
-    internal consistency with selectivity. The sum of all yields is equal to the 
+    and selectivity. By default, uses product-based conversion of feedstock for an
+    internal consistency with selectivity. The sum of all yields is equal to the
     conversion. Implicitly runs :func:`conversion` and :func:`selectivity` on the
     :class:`pd.DataFrame`:
 
@@ -385,9 +385,9 @@ def catalytic_yield(
 
     standard
         Internal standard for normalizing the compositions. By default set to "N2".
-    
+
     type
-        Select conversion calculation algorithm, see 
+        Select conversion calculation algorithm, see
         :func:`~dgpost.transform.catalysis.conversion`.
 
     output

--- a/src/dgpost/transform/catalysis.py
+++ b/src/dgpost/transform/catalysis.py
@@ -79,9 +79,9 @@ def conversion(
         {\\sum_{s} n_\\text{el}(s) \\dot{n}_\\text{out}(s)}
 
     Which requires the feedstock :math:`f` to be quantified in the outlet composition.
-    If the outlet composition of :math:`f` is found to be zero at all timesteps, its
-    value in the the inlet composition is used instead, and a "mixed" conversion
-    :math:`X_m` is calculated instead:
+
+    If the outlet composition of :math:`f` is not defined or not suitable, the user 
+    should request a "mixed" conversion :math:`X_m`, which is calculated using:
 
     .. math::
 
@@ -99,10 +99,9 @@ def conversion(
 
     .. note::
 
-        Calculating product-based conversion :math:`X_m` using inlet mole fraction
+        Calculating mixed conversion :math:`X_m` using inlet mole fraction
         of feedstock is not ideal and should be avoided, as the value is strongly
-        convoluted with the :func:`atom_balance` of the mixtures. A warning will be
-        raised by the program.
+        convoluted with the :func:`atom_balance` of the mixtures.
 
     Finally, the calculation of reactant-based (or feedstock-based) conversion,
     :math:`X_r`, proceeds as follows:
@@ -156,6 +155,7 @@ def conversion(
         the conversion calculation algorithm. 
     
     product
+        **Deprecated.** Switches between reactant and product-based conversion.
 
     standard
         Internal standard for normalizing the compositions. By default set to "N2".
@@ -171,7 +171,7 @@ def conversion(
 
     """
     if product is not None:
-        logging.warning(
+        logger.warning(
             "Specifying reactant- and product-based conversion using "
             f"'product' is deprecated and will stop working in dgpost-2.0. "
             "Use 'type={product,reactant,mixed}' instead."
@@ -192,10 +192,10 @@ def conversion(
 
     # expansion factor
     if xin is None and xout is None:
-        logging.debug("Calculation using molar rates. Expansion factor set to 1.0.")
+        logger.debug("Calculation using molar rates. Expansion factor set to 1.0.")
         exp = 1.0
     else:
-        logging.debug(
+        logger.debug(
             "Calculation using molar fractions. Expansion factor derived from '%s'",
             standard,
         )
@@ -355,9 +355,9 @@ def catalytic_yield(
 ) -> None:
     """
     Calculates the catalytic yield :math:`Y_p`, defined as the product of conversion
-    and selectivity. Uses product-based conversion of feedstock for an internal
-    consistency with selectivity. The sum of all yields is equal to the conversion.
-    Implicitly runs :func:`conversion` and :func:`selectivity` on the
+    and selectivity. By default, uses product-based conversion of feedstock for an 
+    internal consistency with selectivity. The sum of all yields is equal to the 
+    conversion. Implicitly runs :func:`conversion` and :func:`selectivity` on the
     :class:`pd.DataFrame`:
 
     .. math::
@@ -385,6 +385,10 @@ def catalytic_yield(
 
     standard
         Internal standard for normalizing the compositions. By default set to "N2".
+    
+    type
+        Select conversion calculation algorithm, see 
+        :func:`~dgpost.transform.catalysis.conversion`.
 
     output
         A :class:`str` prefix for the output variables.

--- a/src/dgpost/transform/catalysis.py
+++ b/src/dgpost/transform/catalysis.py
@@ -26,7 +26,6 @@ cross-matching of the ``feestock``, internal ``standard``, and the components of
 """
 
 import pint
-import numpy as np
 import logging
 
 logger = logging.getLogger(__name__)
@@ -255,8 +254,8 @@ def selectivity(
     """
     Calculates product-based atomic selectivities of all species :math:`s`,
     excluding the ``feedstock`` :math:`f`. The sum of selectivities is normalised
-    to unity. Works with both mole fractions :math:`x` as well as molar rates
-    :math:`\\dot{n}`:
+    to unity. Works with both mole fractions :math:`x` as well as molar production
+    rates :math:`\\dot{n}`:
 
     .. math::
 
@@ -275,6 +274,11 @@ def selectivity(
 
         The selectivity calculation assumes that all products have been determined;
         it provides no information about the mass or atomic balance.
+
+    .. note::
+
+        When molar rates :math:`\\dot{n}` are used, only creation rates (i.e.
+        where :math:`\\dot{n}(p) > 0`) are used for calculation of selectivity.
 
     Parameters
     ----------
@@ -319,6 +323,7 @@ def selectivity(
         if k != fsmi and "out" in v:
             formula = v["chem"].formula
             dnat = out[v["out"]] * element_from_formula(formula, element)
+            dnat = dnat * (dnat > 0)
             if nat_out is None:
                 nat_out = dnat
             else:
@@ -329,7 +334,8 @@ def selectivity(
             formula = v["chem"].formula
             els = element_from_formula(formula, element)
             if els > 0:
-                Sp = out[v["out"]] * els / nat_out
+                nat = out[v["out"]] * els
+                Sp = nat * (nat > 0) / nat_out
                 pretag = f"Sp_{element}" if output is None else output
                 tag = f"{pretag}->{v['out']}"
                 ret[tag] = Sp

--- a/src/dgpost/transform/helpers.py
+++ b/src/dgpost/transform/helpers.py
@@ -301,8 +301,6 @@ def load_data(*cols: tuple[str, str, type]):
                 else:
                     retvals = func(**data_kwargs, **kwargs)
                     for name, qty in retvals.items():
-                        print(f"{name=}")
-                        print(f"{qty=}")
                         if isinstance(qty, pint.Quantity):
                             qty.ito_reduced_units()
                             df[name] = qty.m

--- a/tests/test_catalysis_conversion.py
+++ b/tests/test_catalysis_conversion.py
@@ -166,7 +166,7 @@ def test_catalysis_conversion_transform(inpath, spec, outpath, datadir):
                     "feedstock": "CO2",
                     "rin": "nin",
                     "rout": "nout",
-                    "product": True,
+                    "type": "mixed",
                     "element": "C",
                 }
             ],
@@ -186,27 +186,26 @@ def test_catalysis_conversion_rinxin(datadir):
     os.chdir(datadir)
     df = pd.read_pickle("rinxin.pkl")
     catalysis.conversion(
-        df, feedstock="CH4", xin="xin", xout="xout", product=False, output="Xr1"
+        df, feedstock="CH4", xin="xin", xout="xout", type="reactant", output="Xr1"
     )
     catalysis.conversion(
-        df, feedstock="CH4", rin="nin", rout="nout", product=False, output="Xr2"
+        df, feedstock="CH4", rin="nin", rout="nout", type="reactant", output="Xr2"
     )
     catalysis.conversion(
-        df, feedstock="CH4", xin="xin", xout="xout", product=True, output="Xp1"
+        df, feedstock="CH4", xin="xin", xout="xout", type="product", output="Xp1"
     )
     catalysis.conversion(
-        df, feedstock="CH4", rin="nin", rout="nout", product=True, output="Xp2"
+        df, feedstock="CH4", rin="nin", rout="nout", type="product", output="Xp2"
     )
     catalysis.conversion(
         df, feedstock="CH4", xin="xin", xout="xout", standard="Ar", output="Xp3"
     )
-    df["nout->CH4"] = 0
     catalysis.conversion(
-        df, feedstock="CH4", rin="nin", rout="nout", product=True, output="Xm1"
+        df, feedstock="CH4", rin="nin", rout="nout", type="mixed", output="Xm1"
     )
     del df["nout->CH4"]
     catalysis.conversion(
-        df, feedstock="CH4", rin="nin", rout="nout", product=True, output="Xm2"
+        df, feedstock="CH4", rin="nin", rout="nout", type="mixed", output="Xm2"
     )
     for col in ["Xr1", "Xr2"]:
         assert np.allclose(

--- a/tests/test_catalysis_yield.py
+++ b/tests/test_catalysis_yield.py
@@ -83,8 +83,9 @@ def test_catalysis_yield_rinxin(datadir):
     df = pd.read_pickle("rinxin.pkl")
     catalysis.catalytic_yield(df, feedstock="CH4", xin="xin", xout="xout", output="Yp1")
     catalysis.catalytic_yield(df, feedstock="CH4", rin="nin", rout="nout", output="Yp2")
-    df["nout->CH4"] = 0
-    catalysis.catalytic_yield(df, feedstock="CH4", rin="nin", rout="nout", output="Yp3")
+    catalysis.catalytic_yield(
+        df, feedstock="CH4", rin="nin", rout="nout", type="mixed", output="Yp3"
+    )
     for col in ["Yp1", "Yp2"]:
         assert np.allclose(
             df[f"{col}->CO"],


### PR DESCRIPTION
- Deprecate `product: bool = True` in `catalysis.conversion`.  Use `type: str = {"product", "reactant", "mixed"}` instead. 
- Bound calculation of selectivity from rates to only consider production rates.
- Fix tests, edit docs.