### PR TITLE
Fix performance warning due to fragmented table.

### DIFF
--- a/src/dgpost/main.py
+++ b/src/dgpost/main.py
@@ -102,7 +102,7 @@ def run(path: str, patch: str = None) -> tuple[dict, dict]:
     logger.info("Processing 'transform'.")
     t = spec.get("transform", [])
     for el in t:
-        transform(tables[el["table"]], el["with"], el["using"])
+        tables[el["table"]] = transform(tables[el["table"]], el["with"], el["using"])
 
     logger.info("Processing 'plot'.")
     p = spec.get("plot", [])

--- a/src/dgpost/utils/transform.py
+++ b/src/dgpost/utils/transform.py
@@ -34,4 +34,8 @@ def transform(table: pd.DataFrame, withstr: str, using: list[dict]) -> None:
     m = importlib.import_module(modname)
     func = getattr(m, funcname)
     for argset in using:
-        func(table, **argset)
+        print(f"{table.columns=}")
+        table = func(table, **argset)
+        print(f"{table.columns=}")
+
+    return table

--- a/tests/test_catalysis_atbal.py
+++ b/tests/test_catalysis_atbal.py
@@ -46,7 +46,7 @@ def test_catalysis_atbal_df(inpath, spec, outpath, datadir):
     os.chdir(datadir)
     df = pd.read_pickle(inpath)
     for args in spec:
-        catalysis.atom_balance(df, **args)
+        df = catalysis.atom_balance(df, **args)
     ref = pd.read_pickle(outpath)
     compare_dfs(ref, df)
 
@@ -66,7 +66,7 @@ def test_catalysis_atbal_df(inpath, spec, outpath, datadir):
 def test_catalysis_atbal_transform(inpath, spec, outpath, datadir):
     os.chdir(datadir)
     df = pd.read_pickle(inpath)
-    transform(df, "catalysis.atom_balance", using=spec)
+    df = transform(df, "catalysis.atom_balance", using=spec)
     ref = pd.read_pickle(outpath)
     compare_dfs(ref, df)
 
@@ -87,7 +87,7 @@ def test_catalysis_atbal_transform(inpath, spec, outpath, datadir):
 def test_catalysis_atbal_excel(inpath, spec, outkeys, datadir):
     os.chdir(datadir)
     df = pd.read_excel(inpath)
-    transform(df, "catalysis.atom_balance", using=spec)
+    df = transform(df, "catalysis.atom_balance", using=spec)
     for col in outkeys:
         pd.testing.assert_series_equal(df[col], df["r" + col], check_names=False)
 
@@ -95,10 +95,10 @@ def test_catalysis_atbal_excel(inpath, spec, outkeys, datadir):
 def test_catalysis_atbal_rinxin(datadir):
     os.chdir(datadir)
     df = pd.read_pickle("rinxin.pkl")
-    catalysis.atom_balance(df, xin="xin", xout="xout", element="C", output="C1")
-    catalysis.atom_balance(df, rin="nin", rout="nout", element="C", output="C2")
-    catalysis.atom_balance(df, xin="xin", xout="xout", element="O", output="O1")
-    catalysis.atom_balance(df, rin="nin", rout="nout", element="O", output="O2")
+    df = catalysis.atom_balance(df, xin="xin", xout="xout", element="C", output="C1")
+    df = catalysis.atom_balance(df, rin="nin", rout="nout", element="C", output="C2")
+    df = catalysis.atom_balance(df, xin="xin", xout="xout", element="O", output="O1")
+    df = catalysis.atom_balance(df, rin="nin", rout="nout", element="O", output="O2")
     assert np.allclose(df["C1"], np.array([1.0, 1.0, 0.995, 1.005, 1.01, 0.99]))
     assert np.allclose(df["C2"], np.array([1.0, 1.0, 0.995, 1.005, 1.01, 0.99]))
     assert np.allclose(df["O1"], np.array([1.0, 1.0, 0.95, 1.05, 1.0, 1.0]))

--- a/tests/test_catalysis_conversion.py
+++ b/tests/test_catalysis_conversion.py
@@ -83,7 +83,7 @@ def test_catalysis_conversion_df(inpath, spec, outpath, datadir):
     os.chdir(datadir)
     df = pd.read_pickle(inpath)
     for args in spec:
-        catalysis.conversion(df, **args)
+        df = catalysis.conversion(df, **args)
     ref = pd.read_pickle(outpath)
     compare_dfs(ref, df)
 
@@ -121,7 +121,7 @@ def test_catalysis_conversion_df(inpath, spec, outpath, datadir):
 def test_catalysis_conversion_transform(inpath, spec, outpath, datadir):
     os.chdir(datadir)
     df = pd.read_pickle(inpath)
-    transform(df, "catalysis.conversion", using=spec)
+    df = transform(df, "catalysis.conversion", using=spec)
     ref = pd.read_pickle(outpath)
     compare_dfs(ref, df)
 
@@ -177,7 +177,7 @@ def test_catalysis_conversion_transform(inpath, spec, outpath, datadir):
 def test_catalysis_conversion_excel(inpath, spec, outkeys, datadir):
     os.chdir(datadir)
     df = pd.read_excel(inpath)
-    transform(df, "catalysis.conversion", using=spec)
+    df = transform(df, "catalysis.conversion", using=spec)
     for col in outkeys:
         pd.testing.assert_series_equal(df[col], df["r" + col], check_names=False)
 
@@ -185,26 +185,26 @@ def test_catalysis_conversion_excel(inpath, spec, outkeys, datadir):
 def test_catalysis_conversion_rinxin(datadir):
     os.chdir(datadir)
     df = pd.read_pickle("rinxin.pkl")
-    catalysis.conversion(
+    df = catalysis.conversion(
         df, feedstock="CH4", xin="xin", xout="xout", type="reactant", output="Xr1"
     )
-    catalysis.conversion(
+    df = catalysis.conversion(
         df, feedstock="CH4", rin="nin", rout="nout", type="reactant", output="Xr2"
     )
-    catalysis.conversion(
+    df = catalysis.conversion(
         df, feedstock="CH4", xin="xin", xout="xout", type="product", output="Xp1"
     )
-    catalysis.conversion(
+    df = catalysis.conversion(
         df, feedstock="CH4", rin="nin", rout="nout", type="product", output="Xp2"
     )
-    catalysis.conversion(
+    df = catalysis.conversion(
         df, feedstock="CH4", xin="xin", xout="xout", standard="Ar", output="Xp3"
     )
-    catalysis.conversion(
+    df = catalysis.conversion(
         df, feedstock="CH4", rin="nin", rout="nout", type="mixed", output="Xm1"
     )
     del df["nout->CH4"]
-    catalysis.conversion(
+    df = catalysis.conversion(
         df, feedstock="CH4", rin="nin", rout="nout", type="mixed", output="Xm2"
     )
     for col in ["Xr1", "Xr2"]:

--- a/tests/test_catalysis_selectivity.py
+++ b/tests/test_catalysis_selectivity.py
@@ -57,7 +57,7 @@ def test_catalysis_selectivity_df(inpath, spec, outpath, datadir):
     os.chdir(datadir)
     df = pd.read_pickle(inpath)
     for args in spec:
-        catalysis.selectivity(df, **args)
+        df = catalysis.selectivity(df, **args)
     ref = pd.read_pickle(outpath)
     compare_dfs(ref, df)
 
@@ -78,7 +78,7 @@ def test_catalysis_selectivity_df(inpath, spec, outpath, datadir):
 def test_catalysis_selectivity_transform(inpath, spec, outpath, datadir):
     os.chdir(datadir)
     df = pd.read_pickle(inpath)
-    transform(df, "catalysis.selectivity", using=spec)
+    df = transform(df, "catalysis.selectivity", using=spec)
     ref = pd.read_pickle(outpath)
     compare_dfs(ref, df)
 
@@ -96,7 +96,7 @@ def test_catalysis_selectivity_transform(inpath, spec, outpath, datadir):
 def test_catalysis_selectivity_excel(inpath, spec, outkeys, datadir):
     os.chdir(datadir)
     df = pd.read_excel(inpath)
-    transform(df, "catalysis.selectivity", using=spec)
+    df = transform(df, "catalysis.selectivity", using=spec)
     for col in outkeys:
         pd.testing.assert_series_equal(df[col], df["r" + col], check_names=False)
 
@@ -104,10 +104,10 @@ def test_catalysis_selectivity_excel(inpath, spec, outkeys, datadir):
 def test_catalysis_selectivity_rinxin(datadir):
     os.chdir(datadir)
     df = pd.read_pickle("rinxin.pkl")
-    catalysis.selectivity(df, feedstock="CH4", xout="xout", output="Sp1")
-    catalysis.selectivity(df, feedstock="CH4", rout="nout", output="Sp2")
+    df = catalysis.selectivity(df, feedstock="CH4", xout="xout", output="Sp1")
+    df = catalysis.selectivity(df, feedstock="CH4", rout="nout", output="Sp2")
     df["nout->CH4"] = 0
-    catalysis.selectivity(df, feedstock="CH4", rout="nout", output="Sp3")
+    df = catalysis.selectivity(df, feedstock="CH4", rout="nout", output="Sp3")
     for col in ["Sp1", "Sp2", "Sp3"]:
         assert np.allclose(df[f"{col}->CO"], np.array([0.2, 0.1, 0.1, 0.1, 0.1, 0.1]))
         assert np.allclose(df[f"{col}->CO2"], np.array([0.8, 0.9, 0.9, 0.9, 0.9, 0.9]))

--- a/tests/test_catalysis_yield.py
+++ b/tests/test_catalysis_yield.py
@@ -31,7 +31,7 @@ def test_yield_against_df(inpath, spec, outpath, datadir):
     os.chdir(datadir)
     df = pd.read_pickle(inpath)
     for args in spec:
-        catalysis.catalytic_yield(df, **args)
+        df = catalysis.catalytic_yield(df, **args)
     ref = pd.read_pickle(outpath)
     compare_dfs(ref, df)
 
@@ -51,10 +51,8 @@ def test_yield_against_df(inpath, spec, outpath, datadir):
 def test_catalysis_yield_transform(inpath, spec, outpath, datadir):
     os.chdir(datadir)
     df = pd.read_pickle(inpath)
-    print(df.head())
-    transform(df, "catalysis.catalytic_yield", using=spec)
+    df = transform(df, "catalysis.catalytic_yield", using=spec)
     ref = pd.read_pickle(outpath)
-    print(ref.head())
     compare_dfs(ref, df)
 
 
@@ -73,7 +71,7 @@ def test_catalysis_yield_transform(inpath, spec, outpath, datadir):
 def test_catalysis_yield_excel(inpath, spec, outkeys, datadir):
     os.chdir(datadir)
     df = pd.read_excel(inpath)
-    transform(df, "catalysis.catalytic_yield", using=spec)
+    df = transform(df, "catalysis.catalytic_yield", using=spec)
     for col in outkeys:
         pd.testing.assert_series_equal(df[col], df["r" + col], check_names=False)
 
@@ -81,9 +79,13 @@ def test_catalysis_yield_excel(inpath, spec, outkeys, datadir):
 def test_catalysis_yield_rinxin(datadir):
     os.chdir(datadir)
     df = pd.read_pickle("rinxin.pkl")
-    catalysis.catalytic_yield(df, feedstock="CH4", xin="xin", xout="xout", output="Yp1")
-    catalysis.catalytic_yield(df, feedstock="CH4", rin="nin", rout="nout", output="Yp2")
-    catalysis.catalytic_yield(
+    df = catalysis.catalytic_yield(
+        df, feedstock="CH4", xin="xin", xout="xout", output="Yp1"
+    )
+    df = catalysis.catalytic_yield(
+        df, feedstock="CH4", rin="nin", rout="nout", output="Yp2"
+    )
+    df = catalysis.catalytic_yield(
         df, feedstock="CH4", rin="nin", rout="nout", type="mixed", output="Yp3"
     )
     for col in ["Yp1", "Yp2"]:

--- a/tests/test_electrochemistry_charge.py
+++ b/tests/test_electrochemistry_charge.py
@@ -52,6 +52,6 @@ def test_electrochemistry_charge_direct(spec, ref):
 def test_electrochemistry_charge_df(infile, spec, outfile, datadir):
     os.chdir(datadir)
     df = pd.read_pickle(infile)
-    electrochemistry.charge(df, **spec)
+    df = electrochemistry.charge(df, **spec)
     ref = pd.read_pickle(outfile)
     compare_dfs(ref, df)

--- a/tests/test_electrochemistry_current.py
+++ b/tests/test_electrochemistry_current.py
@@ -53,7 +53,7 @@ def test_electrochemistry_current_direct(spec, ref):
 def test_electrochemistry_current_df(infile, spec, outfile, datadir):
     os.chdir(datadir)
     df = pd.read_pickle(infile)
-    electrochemistry.charge(df, **spec[0])
-    electrochemistry.average_current(df, **spec[1])
+    df = electrochemistry.charge(df, **spec[0])
+    df = electrochemistry.average_current(df, **spec[1])
     ref = pd.read_pickle(outfile)
     compare_dfs(ref, df)

--- a/tests/test_electrochemistry_fe.py
+++ b/tests/test_electrochemistry_fe.py
@@ -82,7 +82,7 @@ def test_electrochemistry_fe_direct(inputs, output):
 def test_electrochemistry_fe_df(infile, spec, outfile, datadir):
     os.chdir(datadir)
     df = pd.read_pickle(infile)
-    rates.flow_to_molar(df, **spec[0])
-    electrochemistry.fe(df, **spec[1])
+    df = rates.flow_to_molar(df, **spec[0])
+    df = electrochemistry.fe(df, **spec[1])
     ref = pd.read_pickle(outfile)
     compare_dfs(ref, df)

--- a/tests/test_electrochemistry_nernst.py
+++ b/tests/test_electrochemistry_nernst.py
@@ -94,6 +94,6 @@ def test_electrochemistry_nernst_df(infile, spec, outfile, datadir):
     os.chdir(datadir)
     df = pd.read_pickle(infile)
     for args in spec:
-        electrochemistry.nernst(df, **args)
+        df = electrochemistry.nernst(df, **args)
     ref = pd.read_pickle(outfile)
     compare_dfs(ref, df)

--- a/tests/test_impedance.py
+++ b/tests/test_impedance.py
@@ -78,12 +78,10 @@ from dgpost.utils import extract, transform
         ),
     ],
 )
-def test_pkl_fit_circuit(filepath, fit_info, expected, datadir):
+def test_impedance_fit_circuit_pkl(filepath, fit_info, expected, datadir):
     os.chdir(datadir)
     df = pd.read_pickle(filepath)
-
-    transform(df, "impedance.fit_circuit", using=fit_info)
-
+    df = transform(df, "impedance.fit_circuit", using=fit_info)
     cols = [col for col in df if col.startswith("fit")]
     for index, expect in enumerate(expected):
         assert len(cols) == len(expect)
@@ -191,14 +189,12 @@ def test_pkl_fit_circuit(filepath, fit_info, expected, datadir):
         ),
     ],
 )
-def test_dg_fit_circuit(data_info, fit_info, expected, datadir):
+def test_impedance_fit_circuit_dg(data_info, fit_info, expected, datadir):
     os.chdir(datadir)
     with open(data_info["filepath"], "r") as infile:
         dg = json.load(infile)
     df = extract(dg, data_info["spec"])
-
-    transform(df, "impedance.fit_circuit", using=fit_info)
-
+    df = transform(df, "impedance.fit_circuit", using=fit_info)
     cols = [col for col in df if col.startswith("fit")]
     for index, expect in enumerate(expected):
         assert len(cols) == len(expect)
@@ -209,14 +205,12 @@ def test_dg_fit_circuit(data_info, fit_info, expected, datadir):
             assert value == pytest.approx(expect[name])
 
 
-def test_direct_fit_circuit(datadir):
+def test_impedance_fit_circuit_direct(datadir):
     os.chdir(datadir)
     df = pd.read_pickle("test.single.Data.pkl")
-
     real = df["Re(Z)"][0]
     imag = df["-Im(Z)"][0]
     freq = df["freq"][0]
-
     fit_info = {
         "circuit": "R0-p(R1,C1)-p(R2,C2)",
         "initial_values": {
@@ -227,9 +221,7 @@ def test_direct_fit_circuit(datadir):
             "C2": 3e-6,
         },
     }
-
     retvals = impedance.fit_circuit(real, imag, freq, **fit_info)
-
     expected = {
         "circuit": "R0-p(R1,C1)-p(R2,C2)",
         "R0": 100,
@@ -238,13 +230,12 @@ def test_direct_fit_circuit(datadir):
         "R2": 150,
         "C2": 1e-6,
     }
-
     for key, val in retvals.items():
         ref = expected.get(key.split(">")[-1])
         assert val == ref or val.m == pytest.approx(ref)
 
 
-def test_calc_circuit(datadir):
+def test_impedance_calc_circuit(datadir):
     os.chdir(datadir)
     calc_info = [
         {
@@ -262,15 +253,12 @@ def test_calc_circuit(datadir):
     ]
     df = pd.DataFrame.from_dict({"freq": [np.logspace(-3, 9, 120)]})
     df.attrs["units"] = {"freq": "Hz"}
-
-    transform(df, "impedance.calc_circuit", using=calc_info)
-
+    df = transform(df, "impedance.calc_circuit", using=calc_info)
     ref = pd.read_pickle("test.single.Data.pkl")
-
     cols = [col for col in df if col.startswith("test")]
     for col in cols:
         name = col.split("->")[-1]
-        np.testing.assert_array_equal(df[col].iloc[0], ref[name].iloc[0])
+        assert np.array_equal(df[col].iloc[0], ref[name].iloc[0])
         assert df.attrs["units"][col] == ref.attrs["units"][name]
 
 
@@ -320,10 +308,10 @@ def test_calc_circuit(datadir):
         ),
     ],
 )
-def test_lowest_real(filepath, inp_extr, inp_using, expected, datadir):
+def test_impedance_lowest_real(filepath, inp_extr, inp_using, expected, datadir):
     os.chdir(datadir)
     with open(filepath, "r") as infile:
         dg = json.load(infile)
     df = extract(dg, inp_extr)
-    transform(df, "impedance.lowest_real_impedance", using=inp_using)
-    np.testing.assert_allclose(expected, unp.nominal_values(df["min Re(Z)"]))
+    df = transform(df, "impedance.lowest_real_impedance", using=inp_using)
+    assert np.allclose(expected, unp.nominal_values(df["min Re(Z)"]))

--- a/tests/test_namespace_combine.py
+++ b/tests/test_namespace_combine.py
@@ -71,7 +71,7 @@ def test_namespace_combine_direct(a, b, conflicts, output):
 def test_namespace_combine_excel(inpath, spec, outprefix, datadir):
     os.chdir(datadir)
     df = pd.read_excel(inpath)
-    transform(df, "namespace.combine", using=spec)
+    df = transform(df, "namespace.combine", using=spec)
     for col in df.columns:
         if col.startswith(outprefix):
             pd.testing.assert_series_equal(df[col], df["r" + col], check_names=False)

--- a/tests/test_rates_batchtomolar.py
+++ b/tests/test_rates_batchtomolar.py
@@ -85,6 +85,6 @@ def test_rates_batchtomolar_df(infile, spec, outfile, datadir):
     os.chdir(datadir)
     df = pd.read_pickle(infile)
     for args in spec:
-        rates.batch_to_molar(df, **args)
+        df = rates.batch_to_molar(df, **args)
     ref = pd.read_pickle(outfile)
     compare_dfs(ref, df)

--- a/tests/test_rates_flowtomolar.py
+++ b/tests/test_rates_flowtomolar.py
@@ -65,6 +65,6 @@ def test_rates_flowtomolar_df(infile, spec, outfile, datadir):
     os.chdir(datadir)
     df = pd.read_pickle(infile)
     for args in spec:
-        rates.flow_to_molar(df, **args)
+        df = rates.flow_to_molar(df, **args)
     ref = pd.read_pickle(outfile)
     compare_dfs(ref, df)


### PR DESCRIPTION
In multiple `transforms`, the `DataFrame` may become fragmented, with `pandas` complaining about performance loss. In this PR, the loader function is modified to return an updated `DataFrame`, which is a product of a concatenation.