### PR TITLE
Fix filtering columns.

### DIFF
--- a/src/dgpost/transform/helpers.py
+++ b/src/dgpost/transform/helpers.py
@@ -272,7 +272,7 @@ def load_data(*cols: tuple[str, str, type]):
                         # so we need to match all columns in pd.DataFrame
                         temp = {}
                         for c in df.columns:
-                            if not c.startswith(cval):
+                            if not c.startswith(f"{cval}->"):
                                 continue
                             onlyc = c.split("->")[-1]
                             if uconv:


### PR DESCRIPTION
When columns of a `df` are specified, match using `f"{cval}->"` instead of `cval` to avoid selecting columns with a suffix.