### PR TITLE
Move `rdkit-pypi` dep to `rdkit`

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -5,14 +5,39 @@ Those can be installed using ``pip``:
 
 .. code:: bash
 
-    pip install --pre dgpost
+    pip install dgpost
 
 .. note::
 
-    With the optional argument ``--pre``, the latest tagged & built development 
-    version will be installed. To install the latest release, the ``--pre`` argument
-    may be omitted.
+    With an optional argument ``--pre``, you can install the latest tagged & built 
+    development versions of dgpost. 
 
+You can test whether dgpost has been installed correctly by running either of:
+
+    >>> dgpost --version
+    dgpost version 2.0a4
+
+    >>> dgpost 
+    usage: dgpost [-h] [--version] [-v] [-q] [--patch PATCH] infile
+    dgpost: error: the following arguments are required: infile
+
+.. warning::
+
+    If, after installation on Windows into a ``conda`` environment, the above commands crash with:: 
+    
+        ImportError: DLL load failed while importing rdBase: The specified module could not be found.
+    
+    You might have to re-install the ``rdkit`` library from a compatible source, such as
+    ``conda-forge``. Create a new environment, and install ``rdkit`` using:
+
+    .. code:: bash 
+
+       conda create -n newEnvName python=3.9 rdkit -c conda-forge
+    
+    Then install dgpost using ``pip`` as shown above.
+
+Installation from source
+````````````````````````
 To install dgpost from source on Github, |gh|, you first need to clone the repository 
 and then you can install the development version of the package using ``pip``:
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -5,9 +5,13 @@ Those can be installed using ``pip``:
 
 .. code:: bash
 
-    pip install dgpost
+    pip install --pre dgpost
 
-Use the optional argument ``--pre`` to get the latest tagged development version.
+.. note::
+
+    With the optional argument ``--pre``, the latest tagged & built development 
+    version will be installed. To install the latest release, the ``--pre`` argument
+    may be omitted.
 
 To install dgpost from source on Github, |gh|, you first need to clone the repository 
 and then you can install the development version of the package using ``pip``:

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setuptools.setup(
         "openpyxl",
         "pint>=0.18",
         "chemicals>=1.0.0",
-        "rdkit-pypi>=2022",
+        "rdkit>=2022.3",
         "yadg>=4.1",
         "dgbowl-schemas>=106",
         "matplotlib>=3.5.0",


### PR DESCRIPTION
- clarify installation instructions
- move from `rdkit-pypi` dep to `rdkit` dep.