### PR TITLE
`extract`: Fix xarray dtypes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setuptools.setup(
         "chemicals>=1.0.0",
         "rdkit>=2022.3",
         "h5netcdf~=1.0",
-        "xarray < 2023.11",
+        "xarray ~= 2024.02",
         "xarray-datatree>=0.0.12",
         "dgbowl-schemas>=116",
         "matplotlib>=3.5.0",

--- a/src/dgpost/utils/extract.py
+++ b/src/dgpost/utils/extract.py
@@ -256,7 +256,7 @@ def _(obj: datatree.DataTree, columns: list[dict]) -> list[pd.Series]:
         if len(vals.coords.dims) > 1:
             assert "uts" in vals.coords.dims
             for coord in vals.coords.dims:
-                if vals.coords.dtypes[coord] in {np.dtype("O")}:
+                if vals.coords.dtypes[coord].kind in {"O", "U"}:
                     splits = vals[coord].values
                     break
         else:


### PR DESCRIPTION
Since `xarray >= 2023.11`, unicode string dtypes are correctly preserved. This means we need to fix `extract` appropriately.