### PR TITLE
Use `xarray.DataTree`

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,7 +19,7 @@ sys.path.insert(0, os.path.abspath(os.path.join("..", "..", "src")))
 # -- Project information -----------------------------------------------------
 
 project = "dgpost"
-copyright = "2021-2024, dgpost authors"
+copyright = "2021-2025, dgpost authors"
 author = "Peter Kraus"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,18 +24,17 @@ classifiers = [
 ]
 requires-python = ">= 3.9"
 dependencies = [
-    "numpy",
+    "numpy >= 1.20",
     "uncertainties < 3.2",
     "pandas",
     "openpyxl",
     "pint >= 0.24.1",
-    "chemicals>=1.0.0",
-    "rdkit>=2022.3",
-    "h5netcdf~=1.0",
-    "xarray ~= 2024.02",
-    "xarray-datatree>=0.0.12",
-    "dgbowl-schemas>=116",
-    "matplotlib>=3.5.0",
+    "chemicals >= 1.0.0",
+    "rdkit >= 2022.3",
+    "h5netcdf >= 1.0",
+    "xarray >= 2024.10.0",
+    "dgbowl-schemas >= 116",
+    "matplotlib >= 3.5.0",
     "requests",
 ]
 

--- a/src/dgpost/utils/extract.py
+++ b/src/dgpost/utils/extract.py
@@ -64,7 +64,7 @@ are interpolated onto the index of the existing :class:`pd.DataFrame`.
 
 import numpy as np
 import pandas as pd
-import datatree
+from xarray import DataTree
 import uncertainties as uc
 import uncertainties.unumpy as unp
 from typing import Union, Any, Optional
@@ -83,14 +83,14 @@ logger = logging.getLogger(__name__)
 
 
 def get_step(
-    obj: Union[pd.DataFrame, datatree.DataTree, dict, None],
+    obj: Union[pd.DataFrame, DataTree, dict, None],
     at: Optional[dict] = None,
-) -> Union[pd.DataFrame, datatree.DataTree, list[dict], None]:
+) -> Union[pd.DataFrame, DataTree, list[dict], None]:
     if obj is None:
         return None
     elif isinstance(obj, pd.DataFrame):
         return obj
-    elif isinstance(obj, datatree.DataTree):
+    elif isinstance(obj, DataTree):
         if at is not None and "step" in at:
             return obj[at["step"]]
         elif at is not None and "steps" in at:
@@ -115,7 +115,7 @@ def get_step(
             if isinstance(step, int):
                 assert step < len(obj["steps"]), (
                     f"extract: specified step index {step} is out of bounds "
-                    f"of the supplied datagtam with {len(obj['steps'])} steps."
+                    f"of the supplied datagram with {len(obj['steps'])} steps."
                 )
                 ret += obj["steps"][step]["data"]
             elif isinstance(step, str):
@@ -148,7 +148,7 @@ def get_constant(spec: dict, ts: pd.Index):
 
 
 def extract(
-    obj: Union[dict, pd.DataFrame, datatree.DataTree, None],
+    obj: Union[dict, pd.DataFrame, DataTree, None],
     spec: dict,
     index: pd.Index = None,
 ) -> pd.DataFrame:
@@ -229,8 +229,8 @@ def _(obj: pd.DataFrame, columns: list[dict]) -> list[pd.Series]:
     return series
 
 
-@extract_obj.register(datatree.DataTree)
-def _(obj: datatree.DataTree, columns: list[dict]) -> list[pd.Series]:
+@extract_obj.register(DataTree)
+def _(obj: DataTree, columns: list[dict]) -> list[pd.Series]:
     def get_key_recurse(dt, keys):
         key = keys.pop(0)
         if len(keys) == 0:

--- a/src/dgpost/utils/load.py
+++ b/src/dgpost/utils/load.py
@@ -23,7 +23,7 @@ from uncertainties import ufloat_fromstr, UFloat
 from typing import Union, Any
 import logging
 from dgpost.utils.helpers import arrow_to_multiindex
-import datatree
+from xarray import open_datatree
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +49,7 @@ def load(
 
     if type.lower() == "netcdf":
         logger.debug("loading a NetCDF file from '%s'" % path)
-        return datatree.open_datatree(path, engine="h5netcdf")
+        return open_datatree(path, engine="h5netcdf")
     elif type.lower() == "datagram":
         logger.debug("loading datagram from '%s'" % path)
         with open(path, "r") as infile:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-from setuptools import distutils
+import shutil
 import os
 import pytest
 
@@ -14,10 +14,10 @@ def datadir(tmpdir, request):
     filename = request.module.__file__
     test_dir, _ = os.path.splitext(filename)
     if os.path.isdir(test_dir):
-        distutils.dir_util.copy_tree(test_dir, str(tmpdir))
+        shutil.copytree(test_dir, str(tmpdir), dirs_exist_ok=True)
     base_dir, _ = os.path.split(test_dir)
     common_dir = os.path.join(base_dir, "common")
     if os.path.isdir(common_dir):
-        distutils.dir_util.copy_tree(common_dir, str(tmpdir))
+        shutil.copytree(common_dir, str(tmpdir), dirs_exist_ok=True)
     print(f"{tmpdir=}")
     return tmpdir

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -2,7 +2,7 @@ import pytest
 import json
 import os
 import pandas as pd
-import datatree
+from xarray import open_datatree
 
 from dgpost.utils.helpers import combine_tables
 import dgpost.utils
@@ -248,7 +248,7 @@ def test_extract_single(inpath, spec, outpath, datadir):
     elif inpath.endswith("pkl"):
         data = pd.read_pickle(inpath)
     elif inpath.endswith("nc"):
-        data = datatree.open_datatree(inpath)
+        data = open_datatree(inpath)
     ret = dgpost.utils.extract(data, spec)
     print(f"{ret.head()=}")
     ref = pd.read_pickle(outpath)
@@ -340,7 +340,7 @@ def test_extract_multiple(inpath, spec, outpath, datadir):
     elif inpath.endswith("pkl"):
         data = pd.read_pickle(inpath)
     elif inpath.endswith("nc"):
-        data = datatree.open_datatree(inpath)
+        data = open_datatree(inpath)
     for si, sp in enumerate(spec):
         if si == 0:
             df = dgpost.utils.extract(data, sp)

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -2,7 +2,7 @@ import pytest
 import json
 import os
 import pandas as pd
-import datatree
+from xarray import open_datatree
 
 import dgpost.utils
 from .utils import compare_dfs, compare_datatrees
@@ -79,5 +79,5 @@ def test_load_table(spec, outfile, datadir):
 def test_load_datatree(input, datadir):
     os.chdir(datadir)
     ret = dgpost.utils.load(**input)
-    ref = datatree.open_datatree(input["path"])
+    ref = open_datatree(input["path"])
     compare_datatrees(ret, ref)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,7 +3,6 @@ import pandas as pd
 import numpy as np
 import uncertainties.unumpy as unp
 from PIL import Image, ImageChops
-import datatree
 import xarray as xr
 
 
@@ -58,14 +57,14 @@ def compare_images(path_one, path_two):
     assert equal_content
 
 
-def compare_datatrees(ret: datatree.DataTree, ref: datatree.DataTree):
+def compare_datatrees(ret: xr.DataTree, ref: xr.DataTree):
     for k in ret:
         assert k in ref, f"Entry {k} not present in reference DataTree."
     for k in ref:
         assert k in ret, f"Entry {k} not present in result DataTree."
 
     for k in ret:
-        if isinstance(ret[k], datatree.DataTree):
+        if isinstance(ret[k], xr.DataTree):
             compare_datatrees(ret[k], ref[k])
         elif isinstance(ret[k], (xr.Dataset, xr.DataArray)):
             assert ret[k].to_dict() == ref[k].to_dict()


### PR DESCRIPTION
This makes sure new versions of `yadg` and `dgpost` can be installed alongside each other, by bumping the `xarray` dependency to match that of `yadg`.