### PR TITLE
`transform.reflection`: Peak picking using `scipy.signal.find_peaks`

### DIFF
--- a/docs/source/version.rst
+++ b/docs/source/version.rst
@@ -4,6 +4,7 @@
 .. toctree::
    :maxdepth: 1
 
+   version.v2.2
    version.v2.1
    version.v2.0
    version.v1.1

--- a/docs/source/version.v2.2.rst
+++ b/docs/source/version.v2.2.rst
@@ -1,0 +1,21 @@
+**dgpost**-v2.1
+---------------
+
+.. image:: https://img.shields.io/static/v1?label=dgpost&message=v2.2&color=blue&logo=github
+    :target: https://github.com/dgbowl/dgpost/tree/2.2
+.. image:: https://img.shields.io/static/v1?label=dgpost&message=v2.2&color=blue&logo=pypi
+    :target: https://pypi.org/project/dgpost/2.2/
+.. image:: https://img.shields.io/static/v1?label=release%20date&message=2025-01-30&color=red&logo=pypi
+
+.. sectionauthor::
+    Peter Kraus
+
+Developed in the `ConCat lab <https://tu.berlin/en/concat>`_ at Technische Universität Berlin.
+
+An update to ``dgpost-2.1``, including the following changes:
+
+- modification of peak-picking in :mod:`~dgpost.transform.reflection` to use :func:`scipy.signal.find_peaks`
+
+.. codeauthor::
+    Ueli Sauter,
+    Peter Kraus

--- a/src/dgpost/transform/reflection.py
+++ b/src/dgpost/transform/reflection.py
@@ -37,11 +37,11 @@ from scipy.signal import find_peaks
 from dgpost.utils.helpers import separate_data, load_data
 
 
-def _find_peak(near, absgamma, freq, height = 0.2) -> int:
+def _find_peak(near, absgamma, freq, height=0.2) -> int:
     if near is None:
         return np.argmax((1 - absgamma))
     else:
-        peaks, _ = find_peaks((1 - absgamma), height = height)
+        peaks, _ = find_peaks((1 - absgamma), height=height)
         nearest = None
         for pi in peaks:
             if nearest is None:
@@ -49,7 +49,6 @@ def _find_peak(near, absgamma, freq, height = 0.2) -> int:
             elif abs(freq[pi] - near) < abs(freq[nearest] - near):
                 nearest = pi
         return nearest
-
 
 
 @load_data(


### PR DESCRIPTION
Reworks the pruning functions to use `scipy.signal.find_peaks`, so that `near` can be used to identify nearest local peak in Γ.