### PR TITLE
`electrons_from_smiles`: Account for overall charge of SMILES

### DIFF
--- a/src/dgpost/utils/helpers.py
+++ b/src/dgpost/utils/helpers.py
@@ -98,7 +98,7 @@ def electrons_from_smiles(
     charges = defaultdict(lambda: 0)
     charges.update(ions)
     mol = Chem.AddHs(Chem.MolFromSmiles(smiles))
-    n = 0
+    n = -Chem.GetFormalCharge(mol)
     for atom in mol.GetAtoms():
         ela = periodic_table[atom.GetAtomicNum()].elneg
         for bond in atom.GetBonds():

--- a/tests/test_electrochemistry_fe.py
+++ b/tests/test_electrochemistry_fe.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 from dgpost.transform import electrochemistry, rates
+from dgpost.utils.helpers import search_chemical, electrons_from_smiles
 import numpy as np
 import pandas as pd
 import pint
@@ -107,3 +108,20 @@ def test_electrochemistry_fe_df(infile, spec, outfile, datadir):
     print(f"{ref.head()=}")
     df.to_pickle(outfile)
     compare_dfs(ref, df)
+
+
+@pytest.mark.parametrize(
+    "chem, spec, charge",
+    [
+        ("H2O", {"H": 1, "O": -2}, 0.0),
+        ("NH3", {"N": -3, "H": 1}, 0.0),
+        ("NH4+", {"N": -3, "H": 1}, 0.0),
+        ("HNO3", {"N": 5, "O": -2, "H": 1}, 0.0),
+        ("HNO2", {"N": 5, "O": -2, "H": 1}, 2.0),
+        ("NO3-", {"N": 5, "O": -2}, 0.0),
+        ("NO2-", {"N": 5, "O": -2}, 2.0),
+    ],
+)
+def test_formal_charges(chem, spec, charge):
+    mol = search_chemical(chem)
+    assert electrons_from_smiles(mol.smiles, spec) == charge


### PR DESCRIPTION
Thanks to Alessandro for bringing this up:

`electrons_from_smiles()` should return the same value for `HNO3` and `NO3-` given the same input ions, since in both cases the `N` is in 5+ and `O` is in 2- state. This means we need to account for the formal charge of the molecule (-1 in `NO3-` and 0 in `HNO3`).